### PR TITLE
Fix typo in note.md

### DIFF
--- a/doc/note.md
+++ b/doc/note.md
@@ -36,7 +36,7 @@ Criaremos a abstração com as definições dos contratos a serem seguidos por c
   npm i -D jest ts-jest @types/jest
 ```
 
-- Aplicar as configurções necessárias no arquivo jest.config.
+- Aplicar as configurações necessárias no arquivo jest.config.
 
 ### Definição de SUT
 


### PR DESCRIPTION
## Summary
- correct misspelling in `doc/note.md`

## Testing
- `grep -n "configurações" -n doc/note.md`

------
https://chatgpt.com/codex/tasks/task_e_68713a189d688327a6e8fb9976a08624