### PR TITLE
Fix awaiting conflict error assertion

### DIFF
--- a/src/products/application/usecases/create-product.usecase.spec.ts
+++ b/src/products/application/usecases/create-product.usecase.spec.ts
@@ -39,7 +39,7 @@ describe('CreateProductUseCase Unit Test', () => {
     }
 
     await sut.execute(props)
-    expect(sut.execute(props)).rejects.toBeInstanceOf(ConflictError)
+    await expect(sut.execute(props)).rejects.toBeInstanceOf(ConflictError)
   })
 
   it('should throws error when name not provided', async () => {


### PR DESCRIPTION
## Summary
- ensure `CreateProductUseCase` conflict check uses `await`

## Testing
- `npm test` *(fails: expect(received).rejects.toBeInstanceOf())*

------
https://chatgpt.com/codex/tasks/task_e_68713a392de0832780683aabb198beeb