### PR TITLE
Fix updated_at in UsersDataBuilder

### DIFF
--- a/src/users/infrastructure/test/helpers/users-data-builder.ts
+++ b/src/users/infrastructure/test/helpers/users-data-builder.ts
@@ -12,6 +12,6 @@ export function UsersDataBuilder(props: Partial<UserModel>): UserModel {
     password: props.password ?? faker.internet.password(),
     avatar: props.avatar ?? faker.image.avatar(),
     created_at: props.created_at ?? new Date(),
-    updated_at: props.created_at ?? new Date(),
+    updated_at: props.updated_at ?? new Date(),
   }
 }


### PR DESCRIPTION
## Summary
- ensure the test helper UsersDataBuilder sets `updated_at` based on the provided props

## Testing
- `npm run lint` *(fails: ConflictError variable unused, etc.)*
- `npm test` *(fails: JestAssertionError in create-user.usecase.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68713a2bd518832796859f2388d92cb9